### PR TITLE
api docs: fix typo in json

### DIFF
--- a/docs/advance-settings/api.md
+++ b/docs/advance-settings/api.md
@@ -91,7 +91,7 @@ Send a POST request to https://[your instance]/eapi/v1/chore. There must be a js
 ```jsx title="Sample body"
 {
     "Name": "Record TV on a VHS tape like it's 1990",
-    "DueDate": "2025-08-30T19:51:50.000Z",
+    "DueDate": "2025-08-30T19:51:50.000Z"
 }
 ```
 


### PR DESCRIPTION
the JSON for the request body in the create chore example had a trailing JSON that isn't valid and wouldn't be accepted by the server.